### PR TITLE
Integrate full DiffusionDrive inference pipeline

### DIFF
--- a/selfdrive/model_bridge/adapter.py
+++ b/selfdrive/model_bridge/adapter.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Any
+from dataclasses import dataclass, field
+from typing import Any, Sequence
 
 import numpy as np
 from cereal import log
@@ -23,6 +23,11 @@ class DiffusionDriveResponse:
   model_execution_time: float | None
   status: str | None
   valid: bool
+  lane_lines: list[np.ndarray] = field(default_factory=list)
+  lane_line_probs: list[float] = field(default_factory=list)
+  road_edges: list[np.ndarray] = field(default_factory=list)
+  road_edge_stds: list[float] = field(default_factory=list)
+  leads: list[dict[str, float]] = field(default_factory=list)
 
   @classmethod
   def from_dict(cls, payload: dict[str, Any]) -> "DiffusionDriveResponse":
@@ -67,6 +72,108 @@ class DiffusionDriveResponse:
     if not isinstance(meta, dict):
       meta = {}
 
+    def _parse_path(data: Any) -> np.ndarray:
+      if isinstance(data, dict):
+        xs = data.get("x")
+        ys = data.get("y")
+        if isinstance(xs, Sequence) and isinstance(ys, Sequence) and len(xs) == len(ys) and len(xs) > 0:
+          arr = np.column_stack((np.asarray(xs, dtype=np.float32), np.asarray(ys, dtype=np.float32)))
+        else:
+          points_raw = data.get("points") or data.get("coords")
+          arr = []
+          if isinstance(points_raw, Sequence):
+            for point in points_raw:
+              if isinstance(point, dict):
+                try:
+                  px = float(point.get("x", 0.0))
+                  py = float(point.get("y", 0.0))
+                except (TypeError, ValueError):
+                  continue
+                arr.append((px, py))
+          arr = np.asarray(arr, dtype=np.float32) if arr else np.zeros((0, 2), dtype=np.float32)
+      elif isinstance(data, Sequence):
+        arr = []
+        for point in data:
+          if isinstance(point, dict):
+            try:
+              px = float(point.get("x", 0.0))
+              py = float(point.get("y", 0.0))
+            except (TypeError, ValueError):
+              continue
+            arr.append((px, py))
+        arr = np.asarray(arr, dtype=np.float32) if arr else np.zeros((0, 2), dtype=np.float32)
+      else:
+        arr = np.zeros((0, 2), dtype=np.float32)
+      if arr.size:
+        arr = arr[np.argsort(arr[:, 0])]
+      return arr
+
+    lane_lines_payload = payload.get("lane_lines")
+    lane_lines: list[np.ndarray] = []
+    if isinstance(lane_lines_payload, Sequence):
+      for entry in lane_lines_payload:
+        parsed = _parse_path(entry)
+        if parsed.size:
+          lane_lines.append(parsed)
+
+    lane_probs_payload = payload.get("lane_line_probs")
+    lane_line_probs: list[float] = []
+    if isinstance(lane_probs_payload, Sequence):
+      for value in lane_probs_payload:
+        try:
+          lane_line_probs.append(float(value))
+        except (TypeError, ValueError):
+          lane_line_probs.append(0.0)
+
+    road_edges_payload = payload.get("road_edges")
+    road_edges: list[np.ndarray] = []
+    if isinstance(road_edges_payload, Sequence):
+      for entry in road_edges_payload:
+        parsed = _parse_path(entry)
+        if parsed.size:
+          road_edges.append(parsed)
+
+    road_edge_stds_payload = payload.get("road_edge_stds")
+    road_edge_stds: list[float] = []
+    if isinstance(road_edge_stds_payload, Sequence):
+      for value in road_edge_stds_payload:
+        try:
+          road_edge_stds.append(float(value))
+        except (TypeError, ValueError):
+          road_edge_stds.append(1.0)
+
+    leads_payload = payload.get("leads")
+    leads: list[dict[str, float]] = []
+    if isinstance(leads_payload, Sequence):
+      for lead in leads_payload:
+        if not isinstance(lead, dict):
+          continue
+        try:
+          x = float(lead.get("x", 0.0))
+          y = float(lead.get("y", 0.0))
+          prob = float(lead.get("prob", lead.get("score", 0.0)))
+          heading = float(lead.get("heading", 0.0))
+          length = float(lead.get("length", 4.5))
+          width = float(lead.get("width", 1.8))
+        except (TypeError, ValueError):
+          continue
+        vx = float(lead.get("vx", 0.0)) if isinstance(lead.get("vx"), (float, int)) else 0.0
+        vy = float(lead.get("vy", 0.0)) if isinstance(lead.get("vy"), (float, int)) else 0.0
+        ax = float(lead.get("ax", 0.0)) if isinstance(lead.get("ax"), (float, int)) else 0.0
+        ay = float(lead.get("ay", 0.0)) if isinstance(lead.get("ay"), (float, int)) else 0.0
+        leads.append({
+          "x": x,
+          "y": y,
+          "prob": np.clip(prob, 0.0, 1.0),
+          "heading": heading,
+          "length": length,
+          "width": width,
+          "vx": vx,
+          "vy": vy,
+          "ax": ax,
+          "ay": ay,
+        })
+
     model_execution_time = payload.get("model_execution_time", payload.get("model_execution_time_s"))
     if model_execution_time is not None:
       try:
@@ -87,6 +194,11 @@ class DiffusionDriveResponse:
       model_execution_time=model_execution_time,
       status=status if isinstance(status, str) else None,
       valid=valid,
+      lane_lines=lane_lines,
+      lane_line_probs=lane_line_probs,
+      road_edges=road_edges,
+      road_edge_stds=road_edge_stds,
+      leads=leads,
     )
 
 
@@ -196,11 +308,67 @@ class DiffusionDriveAdapter:
 
     fill_xyz_poly(driving.path, ModelConstants.POLY_PATH_DEGREE, x, y, z)
     driving.meta.laneChangeState = log.LaneChangeState.off
-    driving.meta.laneChangeDirection = log.LaneChangeDirection.none
-    driving.laneLineMeta.leftY = 0.0
-    driving.laneLineMeta.rightY = 0.0
-    driving.laneLineMeta.leftProb = 0.0
-    driving.laneLineMeta.rightProb = 0.0
+    lane_direction = log.LaneChangeDirection.none
+    if curvature.size:
+      if curvature[-1] > 0.02:
+        lane_direction = log.LaneChangeDirection.left
+      elif curvature[-1] < -0.02:
+        lane_direction = log.LaneChangeDirection.right
+    driving.meta.laneChangeDirection = lane_direction
+    def _interpolate_path(path: np.ndarray) -> np.ndarray:
+      if path.shape[0] < 2:
+        return np.zeros_like(x)
+      base_x = path[:, 0]
+      base_y = path[:, 1]
+      return np.interp(x, base_x, base_y, left=base_y[0], right=base_y[-1])
+
+    lane_arrays = [arr.copy() for arr in response.lane_lines]
+    lane_probs = [float(np.clip(prob, 0.0, 1.0)) for prob in response.lane_line_probs]
+    lane_stds = [float(np.clip(np.std(arr[:, 1]) if arr.shape[0] else 1.0, 0.1, 3.0)) for arr in lane_arrays]
+    while len(lane_arrays) < 4:
+      lane_arrays.append(np.zeros((0, 2), dtype=np.float32))
+    while len(lane_probs) < 4:
+      lane_probs.append(0.0)
+    while len(lane_stds) < 4:
+      lane_stds.append(1.0)
+
+    model.init('laneLines', 4)
+    for idx, lane_line in enumerate(model.laneLines):
+      lane_line.t = t.tolist()
+      lane_line.x = x.tolist()
+      lane_values = _interpolate_path(lane_arrays[idx]) if lane_arrays[idx].shape[0] >= 2 else np.zeros_like(x)
+      lane_line.y = lane_values.tolist()
+      lane_line.z = np.zeros_like(x).tolist()
+    model.laneLineProbs = lane_probs[:4]
+    model.laneLineStds = lane_stds[:4]
+
+    road_arrays = [arr.copy() for arr in response.road_edges]
+    road_stds = [float(std) for std in response.road_edge_stds]
+    while len(road_arrays) < 2:
+      road_arrays.append(np.zeros((0, 2), dtype=np.float32))
+    while len(road_stds) < 2:
+      road_stds.append(1.0)
+
+    model.init('roadEdges', 2)
+    for idx, road_edge in enumerate(model.roadEdges):
+      road_edge.t = t.tolist()
+      road_edge.x = x.tolist()
+      road_values = _interpolate_path(road_arrays[idx]) if road_arrays[idx].shape[0] >= 2 else np.zeros_like(x)
+      road_edge.y = road_values.tolist()
+      road_edge.z = np.zeros_like(x).tolist()
+    model.roadEdgeStds = road_stds[:2]
+
+    def _value_at_zero(path: np.ndarray) -> float:
+      if path.shape[0] == 0:
+        return 0.0
+      return float(np.interp(0.0, path[:, 0], path[:, 1], left=path[0, 1], right=path[-1, 1]))
+
+    left_offset = _value_at_zero(road_arrays[0]) if road_arrays else 0.0
+    right_offset = _value_at_zero(road_arrays[1]) if len(road_arrays) > 1 else 0.0
+    driving.laneLineMeta.leftY = left_offset
+    driving.laneLineMeta.rightY = right_offset
+    driving.laneLineMeta.leftProb = lane_probs[0] if lane_probs else 0.0
+    driving.laneLineMeta.rightProb = lane_probs[-1] if lane_probs else 0.0
 
     # Populate modelV2
     model = model_msg.modelV2
@@ -241,36 +409,41 @@ class DiffusionDriveAdapter:
     model.action.desiredAcceleration = desired_accel
     model.action.shouldStop = should_stop
 
-    model.init('laneLines', 4)
-    for lane_line in model.laneLines:
-      lane_line.t = t.tolist()
-      lane_line.x = np.zeros_like(t).tolist()
-      lane_line.y = np.zeros_like(t).tolist()
-      lane_line.z = np.zeros_like(t).tolist()
-    model.laneLineProbs = [0.0] * 4
-    model.laneLineStds = [1.0] * 4
-
-    model.init('roadEdges', 2)
-    for road_edge in model.roadEdges:
-      road_edge.t = t.tolist()
-      road_edge.x = np.zeros_like(t).tolist()
-      road_edge.y = np.zeros_like(t).tolist()
-      road_edge.z = np.zeros_like(t).tolist()
-    model.roadEdgeStds = [1.0, 1.0]
-
+    lead_ts = np.asarray(ModelConstants.LEAD_T_IDXS, dtype=np.float32)
     model.init('leadsV3', 3)
     for lead in model.leadsV3:
-      lead.t = list(ModelConstants.LEAD_T_IDXS)
-      lead.x = [0.0] * len(ModelConstants.LEAD_T_IDXS)
-      lead.y = [0.0] * len(ModelConstants.LEAD_T_IDXS)
-      lead.v = [0.0] * len(ModelConstants.LEAD_T_IDXS)
-      lead.a = [0.0] * len(ModelConstants.LEAD_T_IDXS)
-      lead.xStd = [1.0] * len(ModelConstants.LEAD_T_IDXS)
-      lead.yStd = [1.0] * len(ModelConstants.LEAD_T_IDXS)
-      lead.vStd = [1.0] * len(ModelConstants.LEAD_T_IDXS)
-      lead.aStd = [1.0] * len(ModelConstants.LEAD_T_IDXS)
+      lead.t = lead_ts.tolist()
+      lead.x = [0.0] * len(lead_ts)
+      lead.y = [0.0] * len(lead_ts)
+      lead.v = [0.0] * len(lead_ts)
+      lead.a = [0.0] * len(lead_ts)
+      lead.xStd = [1.0] * len(lead_ts)
+      lead.yStd = [1.0] * len(lead_ts)
+      lead.vStd = [1.0] * len(lead_ts)
+      lead.aStd = [1.0] * len(lead_ts)
       lead.prob = 0.0
       lead.probTime = 0.0
+
+    for idx, lead_data in enumerate(response.leads[:3]):
+      lead = model.leadsV3[idx]
+      x0_lead = float(lead_data.get("x", 0.0))
+      y0_lead = float(lead_data.get("y", 0.0))
+      vx_lead = float(lead_data.get("vx", 0.0))
+      vy_lead = float(lead_data.get("vy", 0.0))
+      ax_lead = float(lead_data.get("ax", 0.0))
+      ay_lead = float(lead_data.get("ay", 0.0))
+      width_lead = float(abs(lead_data.get("width", 1.8)))
+      length_lead = float(abs(lead_data.get("length", 4.5)))
+      lead.x = (x0_lead + vx_lead * lead_ts + 0.5 * ax_lead * (lead_ts ** 2)).tolist()
+      lead.y = (y0_lead + vy_lead * lead_ts + 0.5 * ay_lead * (lead_ts ** 2)).tolist()
+      lead.v = (vx_lead + ax_lead * lead_ts).tolist()
+      lead.a = [ax_lead] * len(lead_ts)
+      lead.xStd = [max(0.3, width_lead * 0.25)] * len(lead_ts)
+      lead.yStd = [max(0.3, length_lead * 0.25)] * len(lead_ts)
+      lead.vStd = [1.0] * len(lead_ts)
+      lead.aStd = [1.0] * len(lead_ts)
+      lead.prob = float(np.clip(lead_data.get("prob", 0.0), 0.0, 1.0))
+      lead.probTime = float(lead_ts[min(len(lead_ts) - 1, np.argmax(np.abs(lead.v)))]) if lead.v else 0.0
 
     meta = model.meta
     engaged_prob = None
@@ -283,7 +456,7 @@ class DiffusionDriveAdapter:
     meta.desirePrediction = [0.0] * ModelConstants.DESIRE_LEN
     meta.hardBrakePredicted = False
     meta.laneChangeState = log.LaneChangeState.off
-    meta.laneChangeDirection = log.LaneChangeDirection.none
+    meta.laneChangeDirection = lane_direction
 
     disengage = meta.init('disengagePredictions')
     disengage.t = list(ModelConstants.META_T_IDXS)
@@ -306,16 +479,34 @@ class DiffusionDriveAdapter:
     camera = camera_odometry_msg.cameraOdometry
     camera.frameId = frame.frame_id
     camera.timestampEof = frame.timestamp_eof
-    camera.trans = [0.0, 0.0, 0.0]
-    camera.rot = [0.0, 0.0, 0.0]
-    camera.transStd = [1.0, 1.0, 1.0]
-    camera.rotStd = [1.0, 1.0, 1.0]
-    camera.wideFromDeviceEuler = [0.0, 0.0, 0.0]
-    camera.wideFromDeviceEulerStd = [1.0, 1.0, 1.0]
-    camera.roadTransformTrans = [0.0, 0.0, 0.0]
-    camera.roadTransformTransStd = [1.0, 1.0, 1.0]
+    if t.size >= 2:
+      camera_odometry_msg.valid = valid
+      trans_vec = [float(x[1] - x[0]), float(y[1] - y[0]), float(z[1] - z[0])]
+      camera.trans = trans_vec
+      camera.rot = [0.0, 0.0, float(heading[1] - heading[0])]
+      speed_std = float(np.std(speed)) if speed.size else 0.1
+      rot_std = float(np.clip(abs(heading_rate[0]), 0.01, 0.5)) if heading_rate.size else 0.1
+      camera.transStd = [max(0.05, speed_std * 0.1)] * 3
+      camera.rotStd = [0.1, 0.1, rot_std]
+    else:
+      camera_odometry_msg.valid = False
+      camera.trans = [0.0, 0.0, 0.0]
+      camera.rot = [0.0, 0.0, 0.0]
+      camera.transStd = [1.0, 1.0, 1.0]
+      camera.rotStd = [1.0, 1.0, 1.0]
+    lane_center_offset = 0.5 * (left_offset + right_offset)
+    camera.wideFromDeviceEuler = [0.0, 0.0, float(heading[0] if heading.size else 0.0)]
+    camera.wideFromDeviceEulerStd = [0.1, 0.1, 0.1]
+    camera.roadTransformTrans = [0.0, float(lane_center_offset), 0.0]
+    camera.roadTransformTransStd = [0.2, 0.2, 0.2]
 
-    model_sp_msg.modelDataV2SP.laneTurnDirection = log.ModelDataV2SP.TurnDirection.none
+    lane_turn = log.ModelDataV2SP.TurnDirection.none
+    if curvature.size:
+      if curvature[-1] > 0.02:
+        lane_turn = log.ModelDataV2SP.TurnDirection.left
+      elif curvature[-1] < -0.02:
+        lane_turn = log.ModelDataV2SP.TurnDirection.right
+    model_sp_msg.modelDataV2SP.laneTurnDirection = lane_turn
 
     return BridgeOutputs(
       model_msg=model_msg,

--- a/tools/diffusiondrive/server/diffusiondrive_server.py
+++ b/tools/diffusiondrive/server/diffusiondrive_server.py
@@ -2,59 +2,418 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
+import sys
 import time
-from typing import Any
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Sequence
 
+import cv2
 import numpy as np
+import torch
 import zmq
 
 
-def build_response(header: dict[str, Any], horizon_s: float) -> dict[str, Any]:
-  seq = int(header.get("seq", 0))
-  mono_time_ns = int(header.get("mono_time_ns", 0))
-  car_state = header.get("car_state") or {}
-  v_ego = float(car_state.get("v_ego", 0.0))
+@dataclass
+class TrajectoryBundle:
+  times: np.ndarray
+  xyz: np.ndarray
+  heading: np.ndarray
 
-  times = np.linspace(0.0, horizon_s, num=10)
-  x = v_ego * times
-  y = np.zeros_like(times)
 
-  trajectory = [{"t": float(t), "x": float(xi), "y": float(yi)} for t, xi, yi in zip(times, x, y)]
+def _load_diffusiondrive(repo_root: Path) -> None:
+  repo_path = repo_root.expanduser().resolve()
+  if not repo_path.exists():
+    raise FileNotFoundError(f"DiffusionDrive repository not found at {repo_root}")
+  if str(repo_path) not in sys.path:
+    sys.path.insert(0, str(repo_path))
 
-  return {
-    "seq": seq,
-    "mono_time_ns": mono_time_ns,
-    "horizon_s": horizon_s,
-    "trajectory": trajectory,
-    "confidence": 0.8,
-    "velocity": v_ego,
-    "status": "dummy",
-  }
+
+def _nv12_to_rgb(buffer: memoryview | bytes, width: int, height: int, stride: int) -> np.ndarray:
+  frame = np.frombuffer(buffer, dtype=np.uint8)
+  expected = stride * height * 3 // 2
+  if frame.size < expected:
+    raise ValueError(f"Frame payload too small: {frame.size} < {expected}")
+
+  y_plane = frame[:stride * height].reshape((height, stride))
+  uv_plane = frame[stride * height:expected].reshape((height // 2, stride))
+
+  yuv = np.vstack((y_plane[:, :width], uv_plane[:, :width]))
+  yuv = np.ascontiguousarray(yuv)
+  rgb = cv2.cvtColor(yuv, cv2.COLOR_YUV2RGB_NV12)
+  return rgb
+
+
+def _apply_warp(image: np.ndarray, warp_matrix: np.ndarray | None) -> np.ndarray:
+  if warp_matrix is None:
+    return image
+  try:
+    warped = cv2.warpPerspective(image, warp_matrix, (image.shape[1], image.shape[0]))
+    return warped
+  except cv2.error:
+    return image
+
+
+def _crop_and_resize(image: np.ndarray, output_size: tuple[int, int]) -> np.ndarray:
+  target_w, target_h = output_size
+  aspect = target_w / target_h
+  height, width = image.shape[:2]
+  if width <= 0 or height <= 0:
+    raise ValueError("Invalid frame dimensions")
+
+  frame_aspect = width / height
+  if frame_aspect > aspect:
+    new_width = int(height * aspect)
+    offset_x = max((width - new_width) // 2, 0)
+    cropped = image[:, offset_x:offset_x + new_width]
+  else:
+    new_height = int(width / aspect)
+    offset_y = max((height - new_height) // 2, 0)
+    cropped = image[offset_y:offset_y + new_height, :]
+  resized = cv2.resize(cropped, (target_w, target_h), interpolation=cv2.INTER_AREA)
+  return resized
+
+
+def _build_status_vector(car_state: dict[str, Any] | None) -> torch.Tensor:
+  driving_command = torch.tensor([1.0, 0.0, 0.0, 0.0], dtype=torch.float32)
+  if not car_state:
+    velocity = torch.zeros(2, dtype=torch.float32)
+    acceleration = torch.zeros(2, dtype=torch.float32)
+  else:
+    v_ego = float(car_state.get("v_ego", 0.0))
+    a_ego = float(car_state.get("a_ego", 0.0))
+    lateral_v = float(car_state.get("v_ego_lat", 0.0))
+    lateral_a = float(car_state.get("a_ego_lat", 0.0))
+    velocity = torch.tensor([v_ego, lateral_v], dtype=torch.float32)
+    acceleration = torch.tensor([a_ego, lateral_a], dtype=torch.float32)
+  return torch.concatenate((driving_command, velocity, acceleration))
+class DiffusionDriveModel:
+  def __init__(self, repo: Path, weights: Path, device: str, plan_anchor: Path | None,
+               dtype: str = "float32") -> None:
+    _load_diffusiondrive(repo)
+
+    from navsim.agents.diffusiondrive.transfuser_config import TransfuserConfig  # type: ignore
+    from navsim.agents.diffusiondrive.transfuser_model_v2 import V2TransfuserModel  # type: ignore
+
+    self.device = torch.device(device)
+    self.dtype = torch.float16 if dtype == "float16" else torch.float32
+
+    self.config = TransfuserConfig()
+    if plan_anchor is not None:
+      self.config.plan_anchor_path = str(plan_anchor)
+    else:
+      anchor = self._discover_plan_anchor(weights)
+      if anchor is not None:
+        self.config.plan_anchor_path = str(anchor)
+
+    if not Path(self.config.plan_anchor_path).expanduser().exists():
+      raise FileNotFoundError(f"Plan anchor not found: {self.config.plan_anchor_path}")
+
+    self.model = V2TransfuserModel(self.config)
+    self.model.eval()
+    self.model.to(self.device)
+
+    state_dict = self._load_state_dict(weights)
+    missing, unexpected = self.model.load_state_dict(state_dict, strict=False)
+    if missing:
+      print(f"Warning: missing keys when loading checkpoint: {sorted(missing)}")
+    if unexpected:
+      print(f"Warning: unexpected keys when loading checkpoint: {sorted(unexpected)}")
+
+    self.interval_s = float(getattr(self.config.trajectory_sampling, "interval_length", 0.5))
+    self.horizon_s = float(getattr(self.config.trajectory_sampling, "time_horizon", 4.0))
+
+  def _load_state_dict(self, weights: Path) -> dict[str, torch.Tensor]:
+    checkpoint = torch.load(str(weights), map_location=self.device)
+    if isinstance(checkpoint, dict) and "state_dict" in checkpoint:
+      checkpoint = checkpoint["state_dict"]
+
+    state_dict: dict[str, torch.Tensor] = {}
+    if isinstance(checkpoint, dict):
+      for key, value in checkpoint.items():
+        new_key = key
+        if new_key.startswith("agent."):
+          new_key = new_key[len("agent."):]
+        if new_key.startswith("_transfuser_model."):
+          new_key = new_key[len("_transfuser_model."):]
+        if new_key.startswith("model."):
+          new_key = new_key[len("model."):]
+        state_dict[new_key] = value.to(self.device)
+    else:
+      raise ValueError("Unsupported checkpoint format")
+    return state_dict
+
+  def _discover_plan_anchor(self, weights: Path) -> Path | None:
+    weights_path = Path(weights).expanduser().resolve()
+    search_root = weights_path.parent
+    for candidate in search_root.rglob("*.npy"):
+      if "kmeans" in candidate.name and "traj" in candidate.name:
+        return candidate
+    return None
+
+  def infer(self, header: dict[str, Any], frame_bytes: memoryview | bytes) -> dict[str, Any]:
+    width = int(header.get("width", 0))
+    height = int(header.get("height", 0))
+    stride = int(header.get("stride", width))
+    calibration = header.get("calibration") or {}
+    warp_matrix = None
+    if calibration:
+      warp = calibration.get("warp_matrix")
+      if isinstance(warp, Sequence):
+        warp_matrix = np.asarray(warp, dtype=np.float32).reshape(3, 3)
+
+    rgb = _nv12_to_rgb(frame_bytes, width, height, stride)
+    if warp_matrix is not None:
+      rgb = _apply_warp(rgb, warp_matrix)
+    rgb = _crop_and_resize(rgb, (1024, 256))
+    rgb = cv2.cvtColor(rgb, cv2.COLOR_RGB2BGR)
+
+    camera_tensor = torch.from_numpy(rgb).permute(2, 0, 1).to(torch.float32) / 255.0
+    camera_tensor = camera_tensor.unsqueeze(0).to(self.device, dtype=self.dtype)
+
+    lidar_shape = (1, 1, self.config.lidar_resolution_height, self.config.lidar_resolution_width)
+    lidar_tensor = torch.zeros(lidar_shape, device=self.device, dtype=self.dtype)
+
+    status_vector = _build_status_vector(header.get("car_state"))
+    status_tensor = status_vector.unsqueeze(0).to(self.device, dtype=self.dtype)
+
+    with torch.inference_mode():
+      outputs = self.model({
+        "camera_feature": camera_tensor,
+        "lidar_feature": lidar_tensor,
+        "status_feature": status_tensor,
+      })
+
+    trajectory = outputs["trajectory"].squeeze(0).to(torch.float32).cpu().numpy()
+    traj_bundle = self._build_trajectory_bundle(trajectory)
+
+    bev_map = outputs.get("bev_semantic_map")
+    agents = outputs.get("agent_states"), outputs.get("agent_labels")
+    lane_info = self._extract_lane_geometry(bev_map)
+    agents_info = self._extract_agents(*agents)
+
+    confidence = self._compute_confidence(traj_bundle)
+    velocity_ref = self._estimate_velocity(traj_bundle)
+    should_stop = bool(velocity_ref < 0.2 or confidence < 0.25)
+
+    response: dict[str, Any] = {
+      "seq": int(header.get("seq", 0)),
+      "mono_time_ns": int(header.get("mono_time_ns", 0)),
+      "horizon_s": float(self.horizon_s),
+      "trajectory": [
+        {"t": float(t), "x": float(x), "y": float(y), "z": float(z), "heading": float(h)}
+        for t, (x, y, z), h in zip(traj_bundle.times, traj_bundle.xyz, traj_bundle.heading)
+      ],
+      "confidence": float(confidence),
+      "velocity": float(velocity_ref),
+      "status": "ok" if trajectory.shape[0] >= 2 else "invalid",
+      "model_execution_time": None,
+      "meta": {
+        "should_stop": should_stop,
+        "lane_width": lane_info.get("lane_width"),
+        "lane_samples": lane_info.get("sampled_forward"),
+      },
+      "lane_lines": lane_info.get("lane_lines"),
+      "lane_line_probs": lane_info.get("lane_line_probs"),
+      "road_edges": lane_info.get("road_edges"),
+      "road_edge_stds": lane_info.get("road_edge_stds"),
+      "leads": agents_info,
+    }
+    return response
+
+  def _build_trajectory_bundle(self, trajectory: np.ndarray) -> TrajectoryBundle:
+    if trajectory.ndim != 2 or trajectory.shape[1] < 2:
+      raise ValueError("Trajectory tensor has unexpected shape")
+
+    num_points = trajectory.shape[0]
+    times = np.linspace(0.0, self.horizon_s, num=num_points, dtype=np.float32)
+    xyz = np.zeros((num_points, 3), dtype=np.float32)
+    xyz[:, 0:2] = trajectory[..., :2]
+    heading = trajectory[..., 2].astype(np.float32)
+    return TrajectoryBundle(times=times, xyz=xyz, heading=heading)
+
+  def _estimate_velocity(self, bundle: TrajectoryBundle) -> float:
+    if bundle.times.size < 2:
+      return 0.0
+    dt = float(bundle.times[1] - bundle.times[0])
+    if dt <= 0:
+      dt = self.interval_s
+    dx = bundle.xyz[1, 0] - bundle.xyz[0, 0]
+    dy = bundle.xyz[1, 1] - bundle.xyz[0, 1]
+    speed = math.hypot(dx, dy) / max(dt, 1e-3)
+    return speed
+
+  def _compute_confidence(self, bundle: TrajectoryBundle) -> float:
+    if bundle.times.size < 3:
+      return 0.0
+    dt = np.diff(bundle.times)
+    dt[dt <= 0] = self.interval_s
+    vx = np.gradient(bundle.xyz[:, 0], bundle.times)
+    vy = np.gradient(bundle.xyz[:, 1], bundle.times)
+    ax = np.gradient(vx, bundle.times)
+    ay = np.gradient(vy, bundle.times)
+    speed = np.hypot(vx, vy)
+    curvature_denom = np.clip(vx * vx + vy * vy, 1e-3, None) ** 1.5
+    curvature = np.nan_to_num((vx * ay - vy * ax) / curvature_denom)
+    speed_var = float(np.var(speed))
+    curvature_mag = float(np.mean(np.abs(curvature)))
+    confidence = math.exp(-0.05 * speed_var - 0.5 * curvature_mag)
+    return float(np.clip(confidence, 0.0, 1.0))
+
+  def _extract_lane_geometry(self, bev_map: torch.Tensor | None) -> dict[str, Any]:
+    if bev_map is None:
+      return {
+        "lane_lines": [],
+        "lane_line_probs": [],
+        "road_edges": [],
+        "road_edge_stds": [],
+      }
+
+    bev = torch.argmax(bev_map.squeeze(0), dim=0).cpu().numpy()
+    height, width = bev.shape
+    pixel = float(self.config.bev_pixel_size)
+    center_col = width / 2.0
+
+    left_samples: list[tuple[float, float]] = []
+    right_samples: list[tuple[float, float]] = []
+    center_samples: list[tuple[float, float]] = []
+    forward_samples: list[float] = []
+
+    for row in range(height):
+      road_cols = np.where(bev[row] == 1)[0]
+      if road_cols.size < 2:
+        continue
+      forward = (height - 1 - row) * pixel
+      left_col = road_cols[0]
+      right_col = road_cols[-1]
+      left_y = (center_col - left_col) * pixel
+      right_y = (center_col - right_col) * pixel
+      centre_y = 0.5 * (left_y + right_y)
+      left_samples.append((forward, left_y))
+      right_samples.append((forward, right_y))
+      center_samples.append((forward, centre_y))
+      forward_samples.append(forward)
+
+    lane_lines = []
+    lane_probs = []
+    road_edges = []
+    road_edge_stds = []
+
+    def _pack(points: Iterable[tuple[float, float]]) -> dict[str, Any]:
+      arr = np.asarray(list(points), dtype=np.float32)
+      return {"x": arr[:, 0].tolist(), "y": arr[:, 1].tolist()}
+
+    if left_samples:
+      lane_lines.append(_pack(left_samples))
+      lane_probs.append(0.6)
+      road_edges.append(_pack(left_samples))
+      road_edge_stds.append(0.5)
+    if center_samples:
+      lane_lines.append(_pack(center_samples))
+      lane_probs.append(0.8)
+    if right_samples:
+      lane_lines.append(_pack(right_samples))
+      lane_probs.append(0.6)
+      road_edges.append(_pack(right_samples))
+      road_edge_stds.append(0.5)
+
+    lane_width = None
+    if left_samples and right_samples:
+      widths = [abs(l - r) for (_, l), (_, r) in zip(left_samples, right_samples)]
+      if widths:
+        lane_width = float(np.mean(widths))
+
+    return {
+      "lane_lines": lane_lines,
+      "lane_line_probs": lane_probs,
+      "road_edges": road_edges,
+      "road_edge_stds": road_edge_stds,
+      "lane_width": lane_width,
+      "sampled_forward": forward_samples,
+    }
+
+  def _extract_agents(self, states: torch.Tensor | None,
+                      labels: torch.Tensor | None) -> list[dict[str, float]]:
+    if states is None or labels is None:
+      return []
+    probs = torch.sigmoid(labels.squeeze(0)).cpu().numpy()
+    boxes = states.squeeze(0).cpu().numpy()
+    agents = []
+    for prob, box in zip(probs, boxes):
+      if prob < 0.2:
+        continue
+      x, y, heading, length, width = map(float, box[:5])
+      if x < -1.0:
+        continue
+      distance = math.hypot(x, y)
+      if distance > 150.0:
+        continue
+      agents.append({
+        "x": x,
+        "y": y,
+        "heading": heading,
+        "length": length,
+        "width": width,
+        "prob": float(prob),
+      })
+
+    agents.sort(key=lambda a: a["x"])
+    return agents[:3]
+
+
+def build_response(model: DiffusionDriveModel, header: dict[str, Any], frame: memoryview | bytes) -> dict[str, Any]:
+  start = time.perf_counter()
+  payload = model.infer(header, frame)
+  payload["model_execution_time"] = time.perf_counter() - start
+  payload["status"] = payload.get("status", "ok")
+  return payload
+
+
+def parse_args() -> argparse.Namespace:
+  parser = argparse.ArgumentParser(description="DiffusionDrive RPC server")
+  parser.add_argument("--bind", default="tcp://0.0.0.0:5555", help="Endpoint to bind the ZeroMQ REP socket")
+  parser.add_argument("--diffusiondrive-dir", required=True, help="Path to the DiffusionDrive repository checkout")
+  parser.add_argument("--weights", required=True, help="Path to the DiffusionDrive checkpoint (.ckpt)")
+  parser.add_argument("--plan-anchor", help="Optional path to plan anchor .npy file")
+  parser.add_argument("--device", default="cuda", help="Torch device (cuda or cpu)")
+  parser.add_argument("--dtype", choices=["float16", "float32"], default="float16", help="Model precision")
+  return parser.parse_args()
 
 
 def main() -> None:
-  parser = argparse.ArgumentParser(description="Reference DiffusionDrive RPC server")
-  parser.add_argument("--bind", default="tcp://0.0.0.0:5555", help="Endpoint to bind the ZeroMQ REP socket")
-  parser.add_argument("--horizon", type=float, default=6.0, help="Trajectory horizon in seconds")
-  args = parser.parse_args()
+  args = parse_args()
+  repo = Path(args.diffusiondrive_dir)
+  weights = Path(args.weights)
+  plan_anchor = Path(args.plan_anchor) if args.plan_anchor else None
+
+  model = DiffusionDriveModel(repo=repo, weights=weights, device=args.device, plan_anchor=plan_anchor, dtype=args.dtype)
 
   context = zmq.Context.instance()
   socket = context.socket(zmq.REP)
   socket.bind(args.bind)
-  print(f"DiffusionDrive dummy server listening on {args.bind}")
+  print(f"DiffusionDrive server listening on {args.bind} using {args.device} ({args.dtype})")
 
   try:
     while True:
-      frames = socket.recv_multipart()
-      if not frames:
+      parts = socket.recv_multipart()
+      if not parts:
         continue
-      header = json.loads(frames[0].decode("utf-8"))
-      start = time.perf_counter()
-      response = build_response(header, args.horizon)
-      response["model_execution_time"] = time.perf_counter() - start
+      header = json.loads(parts[0].decode("utf-8"))
+      frame = parts[1] if len(parts) > 1 else memoryview(b"")
+      try:
+        response = build_response(model, header, frame)
+      except Exception as err:  # pylint: disable=broad-except
+        response = {
+          "seq": int(header.get("seq", 0)),
+          "mono_time_ns": int(header.get("mono_time_ns", 0)),
+          "status": f"error: {err}",
+          "confidence": 0.0,
+          "trajectory": [],
+        }
       socket.send_json(response)
   except KeyboardInterrupt:
-    print("Stopping DiffusionDrive dummy server")
+    print("Stopping DiffusionDrive server")
   finally:
     socket.close(linger=0)
     context.term()


### PR DESCRIPTION
## Summary
- replace the placeholder DiffusionDrive ZeroMQ server with a full inference backend that loads the upstream model, converts the bridge payload, and returns trajectory, lane, edge, and lead data
- update the bridge adapter to consume the richer response, populate lane lines, road edges, leads, and camera odometry, and surface turn direction metadata
- refresh the adapter unit test and README to cover the new behaviour and document the host-side launch workflow

## Testing
- python -m compileall tools/diffusiondrive/server/diffusiondrive_server.py selfdrive/model_bridge/adapter.py selfdrive/model_bridge/tests/test_adapter.py
- pytest selfdrive/model_bridge/tests/test_adapter.py *(fails: ModuleNotFoundError: No module named 'openpilot.common.params_pyx' in this environment)*


------
https://chatgpt.com/codex/tasks/task_e_68d211fd30a0832abb555b5538278e3b