### PR TITLE
Fix diffusion training suite exports and Windows setup

### DIFF
--- a/tools/sunnypilot_training/docs/README.md
+++ b/tools/sunnypilot_training/docs/README.md
@@ -24,10 +24,12 @@ It targets Windows hosts and CARLA 0.10.0.
 1. **Bootstrap the environment**
    ```powershell
    cd tools\sunnypilot_training\windows
-   .\setup_env.ps1 -PythonVersion 3.11.6
+   .\setup_env.ps1
    Import-Module .\env.psm1
    Enter-TrainingEnv
    ```
+   The script defaults to Python 3.7.9 for CARLA 0.10.0 compatibility. Pass `-InstallCUDA` to
+   install CUDA-enabled PyTorch wheels when using an NVIDIA GPU.
 
 2. **Launch CARLA**
    ```powershell

--- a/tools/sunnypilot_training/docs/STEP_BY_STEP.md
+++ b/tools/sunnypilot_training/docs/STEP_BY_STEP.md
@@ -13,12 +13,13 @@ virtual machine.
    ```
 3. **Bootstrap Python, CARLA, and the virtual environment**
    ```powershell
-   .\setup_env.ps1 -PythonVersion 3.11.6 -InstallCarla
+   .\setup_env.ps1 [-InstallCUDA]
    Import-Module .\env.psm1
    Enter-TrainingEnv
    ```
-   This script installs Python, PyTorch (CUDA if available), the CARLA 0.10.0 Python egg,
-   and all training dependencies inside `%LOCALAPPDATA%\sunnypilot-training`.
+   The script installs Python 3.7.9, PyTorch (CUDA wheels when `-InstallCUDA` is specified),
+   the CARLA 0.10.0 Python API, and all training dependencies into the repository `venv/`
+   directory. It also sets the `CARLA_ROOT` user environment variable for later commands.
 4. **Verify GPU visibility**
    ```powershell
    python - <<'PY'
@@ -34,9 +35,9 @@ virtual machine.
 1. In a second PowerShell window (same directory), start CARLA headless:
    ```powershell
    Import-Module .\env.psm1
-   Invoke-Carla -Port 2000 -Quality Epic
+   Invoke-Carla -Port 2000
    ```
-2. CARLA logs appear under `%LOCALAPPDATA%\sunnypilot-training\carla`. Leave this window running.
+2. CARLA uses the `CARLA_ROOT` path configured by `setup_env.ps1`. Leave this window running while collecting data.
 
 ## 3. Collect synthetic driving data
 

--- a/tools/sunnypilot_training/export/common.py
+++ b/tools/sunnypilot_training/export/common.py
@@ -13,8 +13,14 @@ from .metadata import MetadataPackage
 
 def load_checkpoint(checkpoint_path: Path, device: torch.device) -> Tuple[DiffusionVisionModel, DiffusionPolicyModel]:
   checkpoint = torch.load(checkpoint_path, map_location=device)
+  default_policy = DiffusionPolicyModel()
+  diffusion_steps = int(checkpoint.get("diffusion_steps", default_policy.schedule.timesteps))
+  if diffusion_steps != default_policy.schedule.timesteps:
+    policy = DiffusionPolicyModel(diffusion_steps=diffusion_steps)
+  else:
+    policy = default_policy
   vision = DiffusionVisionModel().to(device)
-  policy = DiffusionPolicyModel().to(device)
+  policy = policy.to(device)
   vision.load_state_dict(checkpoint["vision"])
   policy.load_state_dict(checkpoint["policy"])
   vision.eval()

--- a/tools/sunnypilot_training/export/export_policy.py
+++ b/tools/sunnypilot_training/export/export_policy.py
@@ -35,12 +35,13 @@ def main() -> None:
   device = torch.device(args.device)
   _, policy = load_checkpoint(args.checkpoint, device)
   metadata = generate_policy_metadata()
+  metadata.model_checkpoint = str(args.checkpoint)
 
   wrapper = PolicyExportWrapper(policy)
   dummy_inputs = {
-    "features_buffer": torch.zeros(metadata.input_shapes["features_buffer"], device=device),
-    "desire": torch.zeros(metadata.input_shapes["desire"], device=device),
-    "traffic_convention": torch.zeros(metadata.input_shapes["traffic_convention"], device=device),
+    "features_buffer": torch.zeros(*metadata.input_shapes["features_buffer"], device=device),
+    "desire": torch.zeros(*metadata.input_shapes["desire"], device=device),
+    "traffic_convention": torch.zeros(*metadata.input_shapes["traffic_convention"], device=device),
   }
   export_onnx(wrapper, dummy_inputs, args.onnx)
   save_tinygrad_weights(policy, args.tinygrad)

--- a/tools/sunnypilot_training/export/export_vision.py
+++ b/tools/sunnypilot_training/export/export_vision.py
@@ -35,6 +35,7 @@ def main() -> None:
   device = torch.device(args.device)
   vision, _ = load_checkpoint(args.checkpoint, device)
   metadata = generate_vision_metadata()
+  metadata.model_checkpoint = str(args.checkpoint)
 
   wrapper = VisionExportWrapper(vision)
   dummy_inputs = {

--- a/tools/sunnypilot_training/export/metadata.py
+++ b/tools/sunnypilot_training/export/metadata.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+from collections import OrderedDict
 from dataclasses import dataclass
-from typing import Dict, OrderedDict
+from typing import Dict
 
 from ..contracts import (
   POLICY_INPUT_SHAPES,
@@ -60,11 +61,11 @@ def generate_policy_metadata() -> MetadataPackage:
 
 
 def vision_output_shapes() -> Dict[str, tuple[int, ...]]:
-  return dict(VISION_OUTPUT_SHAPES)
+  return OrderedDict(VISION_OUTPUT_SHAPES)
 
 
 def policy_output_shapes() -> Dict[str, tuple[int, ...]]:
-  return dict(POLICY_OUTPUT_SHAPES)
+  return OrderedDict(POLICY_OUTPUT_SHAPES)
 
 
 __all__ = [

--- a/tools/sunnypilot_training/models/modules.py
+++ b/tools/sunnypilot_training/models/modules.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 from typing import Tuple
-from typing import Tuple
 
 import torch
 import torch.nn as nn

--- a/tools/sunnypilot_training/training/configs/default.yaml
+++ b/tools/sunnypilot_training/training/configs/default.yaml
@@ -24,3 +24,11 @@ optim:
 
 diffusion:
   steps: 20
+
+hydra:
+  run:
+    dir: ${output_dir}
+  sweep:
+    dir: ${output_dir}
+    subdir: .
+  output_subdir: null

--- a/tools/sunnypilot_training/training/train.py
+++ b/tools/sunnypilot_training/training/train.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import os
 from pathlib import Path
 from typing import Dict
 
@@ -81,6 +80,7 @@ def save_checkpoint(
       "vision": vision.state_dict(),
       "policy": policy.state_dict(),
       "optimizer": optimizer.state_dict(),
+      "diffusion_steps": policy.schedule.timesteps,
     },
     ckpt_path,
   )
@@ -171,7 +171,7 @@ def main(cfg: DictConfig) -> None:
   )
   scaler = torch.cuda.amp.GradScaler(enabled=(device.type == "cuda" and cfg.mixed_precision))
 
-  output_dir = Path(os.getcwd())
+  output_dir = Path(to_absolute_path(cfg.output_dir))
   output_dir.mkdir(parents=True, exist_ok=True)
 
   for epoch in range(1, cfg.max_epochs + 1):

--- a/tools/sunnypilot_training/windows/start_carla.ps1
+++ b/tools/sunnypilot_training/windows/start_carla.ps1
@@ -1,11 +1,22 @@
 Param(
-  [string]$CarlaPath = "$PSScriptRoot/../../..",
+  [string]$CarlaPath,
   [int]$Port = 2000,
   [switch]$Offscreen
 )
 
 $ErrorActionPreference = "Stop"
-$carlaExe = Join-Path $CarlaPath "CARLA_0.10.0\CarlaUE4.exe"
+
+if (-Not $CarlaPath) {
+  $envRoot = [Environment]::GetEnvironmentVariable("CARLA_ROOT", "User")
+  if (-Not $envRoot) {
+    $CarlaPath = "$PSScriptRoot/../../..\CARLA_0.10.0"
+  }
+  else {
+    $CarlaPath = $envRoot
+  }
+}
+
+$carlaExe = Join-Path $CarlaPath "CarlaUE4.exe"
 if (-Not (Test-Path $carlaExe)) {
   throw "CARLA executable not found at $carlaExe"
 }


### PR DESCRIPTION
## Summary
- ensure exported diffusion models capture checkpoint metadata, respect saved diffusion steps, and use correct dummy tensors
- persist diffusion schedule in training checkpoints, honor the configured output directory, and refine module typing imports
- modernize the Windows setup scripts and documentation so CARLA 0.10.0 installs correctly on Python 3.7.9 and reuse CARLA_ROOT when launching

## Testing
- pytest tools/sunnypilot_training/tests *(skipped: torch dependency not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d2b453fe90832a873a1b000620dd0c