### PR TITLE
Fix CARLA installer path detection on Windows

### DIFF
--- a/tools/sunnypilot_training/windows/setup_env.ps1
+++ b/tools/sunnypilot_training/windows/setup_env.ps1
@@ -207,51 +207,194 @@ function Install-PythonPackages {
   Remove-Item Env:PIP_NO_CACHE_DIR -ErrorAction SilentlyContinue
 }
 
+function Find-CarlaPythonPackage {
+  param(
+    [string]$CarlaRoot
+  )
+
+  $pythonApi = Join-Path $CarlaRoot "PythonAPI"
+  if (-Not (Test-Path $pythonApi)) {
+    return $null
+  }
+
+  $candidateDirs = @(
+    Join-Path $pythonApi "carla\dist",
+    Join-Path $pythonApi "dist"
+  )
+
+  foreach ($dir in $candidateDirs) {
+    if (Test-Path $dir) {
+      $package = Get-ChildItem -Path $dir -File -ErrorAction SilentlyContinue |
+        Where-Object { $_.Extension -in @('.whl', '.egg') } |
+        Select-Object -First 1
+      if ($package) {
+        return [PSCustomObject]@{
+          Package = $package
+          DistDirectory = $dir
+          PythonApi = $pythonApi
+        }
+      }
+    }
+  }
+
+  $fallbackPackage = Get-ChildItem -Path $pythonApi -File -Recurse -ErrorAction SilentlyContinue |
+    Where-Object { $_.Extension -in @('.whl', '.egg') } |
+    Select-Object -First 1
+
+  if ($fallbackPackage) {
+    return [PSCustomObject]@{
+      Package = $fallbackPackage
+      DistDirectory = $fallbackPackage.DirectoryName
+      PythonApi = $pythonApi
+    }
+  }
+
+  return $null
+}
+
+function Resolve-CarlaInstallPath {
+  param(
+    [string]$InstallRoot,
+    [string]$Version
+  )
+
+  if (-not (Test-Path $InstallRoot)) {
+    return $null
+  }
+
+  $versions = @($Version, $Version.Replace('.', '_'))
+  $candidateNames = @()
+
+  foreach ($variant in $versions) {
+    $candidateNames += @(
+      "CARLA_$variant",
+      "CARLA-$variant",
+      "CARLA-$variant-Win64-Shipping",
+      "CARLA_$variant-Win64-Shipping",
+      "Carla-$variant",
+      "Carla-$variant-Win64-Shipping",
+      "Carla_$variant",
+      "Carla_$variant-Win64-Shipping"
+    )
+  }
+
+  $candidateNames = $candidateNames | Select-Object -Unique
+
+  foreach ($name in $candidateNames) {
+    $candidatePath = Join-Path $InstallRoot $name
+    if (Test-Path $candidatePath) {
+      $package = Find-CarlaPythonPackage -CarlaRoot $candidatePath
+      if ($package) {
+        return $candidatePath
+      }
+    }
+  }
+
+  $directories = Get-ChildItem -Path $InstallRoot -Directory -ErrorAction SilentlyContinue
+  foreach ($dir in $directories) {
+    foreach ($versionString in $versions) {
+      if ($dir.Name -like "*$versionString*") {
+        $package = Find-CarlaPythonPackage -CarlaRoot $dir.FullName
+        if ($package) {
+          return $dir.FullName
+        }
+      }
+    }
+  }
+
+  return $null
+}
+
 function Install-CARLA {
   param(
     [string]$Version,
     [string]$Destination
   )
 
+  $targetDir = Join-Path $Destination "CARLA_$Version"
+  $targetFullPath = [System.IO.Path]::GetFullPath($targetDir)
+
+  $existing = Resolve-CarlaInstallPath -InstallRoot $Destination -Version $Version
+  if ($existing) {
+    $existingFullPath = [System.IO.Path]::GetFullPath($existing)
+    if ($existingFullPath -ieq $targetFullPath) {
+      Write-Host "CARLA $Version already installed at $targetDir"
+      return $targetDir
+    }
+
+    Write-Host "Found existing CARLA $Version installation at $existing. Normalizing to $targetDir"
+    if (Test-Path $targetDir) {
+      Remove-Item $targetDir -Recurse -Force
+    }
+    Move-Item -Path $existing -Destination $targetDir
+    return $targetDir
+  }
+
   $token = $Version.Replace('.', '-')
   $carlaZip = "https://tiny.carla.org/carla-$token-windows"
   $downloadPath = Join-Path $env:TEMP "CARLA_$Version.zip"
-  Write-Host "Downloading CARLA $Version"
-  Invoke-WebRequest -Uri $carlaZip -OutFile $downloadPath -MaximumRedirection 5
+  if (Test-Path $downloadPath) {
+    Write-Host "Using existing CARLA $Version archive at $downloadPath"
+  }
+  else {
+    Write-Host "Downloading CARLA $Version"
+    Invoke-WebRequest -Uri $carlaZip -OutFile $downloadPath -MaximumRedirection 5
+  }
+
   Write-Host "Extracting CARLA archive to $Destination"
   if (-Not (Test-Path $Destination)) {
     New-Item -ItemType Directory -Path $Destination | Out-Null
   }
   Expand-Archive -Path $downloadPath -DestinationPath $Destination -Force
   Remove-Item $downloadPath -ErrorAction SilentlyContinue
+
+  $extracted = Resolve-CarlaInstallPath -InstallRoot $Destination -Version $Version
+  if (-not $extracted) {
+    throw "CARLA Python API distribution not found after extracting archive to $Destination"
+  }
+
+  $extractedFullPath = [System.IO.Path]::GetFullPath($extracted)
+  if ($extractedFullPath -ieq $targetFullPath) {
+    return $targetDir
+  }
+
+  if (Test-Path $targetDir) {
+    Remove-Item $targetDir -Recurse -Force
+  }
+
+  Move-Item -Path $extracted -Destination $targetDir
+  return $targetDir
 }
 
 function Install-CarlaPythonModule {
   param(
     [string]$VenvPath,
     [string]$InstallRoot,
-    [string]$Version
+    [string]$Version,
+    [string]$CarlaRoot = $null
   )
 
-  $pythonApi = Join-Path $InstallRoot "CARLA_$Version\PythonAPI"
-  $distDir = Join-Path $pythonApi "carla\dist"
-  if (-Not (Test-Path $distDir)) {
-    throw "CARLA Python API distribution not found at $distDir"
+  if (-not $CarlaRoot) {
+    $CarlaRoot = Resolve-CarlaInstallPath -InstallRoot $InstallRoot -Version $Version
+  }
+  if (-not $CarlaRoot) {
+    throw "CARLA Python API distribution not found for version $Version under $InstallRoot"
   }
 
-  $package = Get-ChildItem -Path $distDir -Include *.whl, *.egg | Select-Object -First 1
-  if (-Not $package) {
-    throw "Unable to locate CARLA wheel/egg in $distDir"
+  $packageInfo = Find-CarlaPythonPackage -CarlaRoot $CarlaRoot
+  if (-not $packageInfo) {
+    throw "Unable to locate CARLA wheel/egg under $CarlaRoot"
   }
 
   $python = Join-Path $VenvPath "Scripts\python.exe"
-  Write-Host "Installing CARLA Python package from $($package.Name)"
-  & $python -m pip install --no-cache-dir $package.FullName
+  Write-Host "Installing CARLA Python package from $($packageInfo.Package.FullName)"
+  & $python -m pip install --no-cache-dir $packageInfo.Package.FullName
 
+  $pythonApi = $packageInfo.PythonApi
   $additionalPaths = @(
-    (Join-Path $pythonApi "carla\lib"),
-    (Join-Path $pythonApi "util"),
-    (Join-Path $pythonApi "agents")
+    (Join-Path (Join-Path $pythonApi 'carla') 'lib'),
+    (Join-Path $pythonApi 'util'),
+    (Join-Path $pythonApi 'agents')
   ) | Where-Object { Test-Path $_ }
 
   if ($additionalPaths.Count -gt 0) {
@@ -263,13 +406,19 @@ function Install-CarlaPythonModule {
 function Configure-CarlaEnvironment {
   param(
     [string]$InstallRoot,
-    [string]$Version
+    [string]$Version,
+    [string]$CarlaRoot = $null
   )
 
-  $carlaRoot = Join-Path $InstallRoot "CARLA_$Version"
-  $carlaRoot = [System.IO.Path]::GetFullPath($carlaRoot)
-  [Environment]::SetEnvironmentVariable("CARLA_ROOT", $carlaRoot, "User")
-  Write-Host "CARLA_ROOT set to $carlaRoot"
+  if (-not $CarlaRoot) {
+    $CarlaRoot = Resolve-CarlaInstallPath -InstallRoot $InstallRoot -Version $Version
+  }
+  if (-not $CarlaRoot) {
+    throw "CARLA installation for version $Version not found under $InstallRoot"
+  }
+  $resolvedCarlaRoot = [System.IO.Path]::GetFullPath($CarlaRoot)
+  [Environment]::SetEnvironmentVariable("CARLA_ROOT", $resolvedCarlaRoot, "User")
+  Write-Host "CARLA_ROOT set to $resolvedCarlaRoot"
 }
 
 $pythonPath = Resolve-Python -Version $PythonVersion
@@ -278,12 +427,12 @@ $venv = Ensure-Venv -PythonExe $pythonPath -ExpectedVersion $PythonVersion
 Install-PythonPackages -VenvPath $venv -UseCUDA:$InstallCUDA
 
 $resolvedInstallDir = [System.IO.Path]::GetFullPath($InstallDir)
-$carlaInstallPath = Join-Path $resolvedInstallDir "CARLA_$CarlaVersion"
-if (-Not (Test-Path $carlaInstallPath)) {
-  Install-CARLA -Version $CarlaVersion -Destination $resolvedInstallDir
+$carlaRoot = Install-CARLA -Version $CarlaVersion -Destination $resolvedInstallDir
+if (-not $carlaRoot) {
+  throw "Failed to locate CARLA installation for version $CarlaVersion"
 }
 
-Install-CarlaPythonModule -VenvPath $venv -InstallRoot $resolvedInstallDir -Version $CarlaVersion
-Configure-CarlaEnvironment -InstallRoot $resolvedInstallDir -Version $CarlaVersion
+Install-CarlaPythonModule -VenvPath $venv -InstallRoot $resolvedInstallDir -Version $CarlaVersion -CarlaRoot $carlaRoot
+Configure-CarlaEnvironment -InstallRoot $resolvedInstallDir -Version $CarlaVersion -CarlaRoot $carlaRoot
 
 Write-Host "Environment setup complete. Activate with:`n`""$venv\Scripts\Activate.ps1""`


### PR DESCRIPTION
## Summary
- normalize extracted CARLA archives to the expected `CARLA_<version>` directory and reuse existing installations
- add logic to locate existing CARLA directories in multiple naming conventions before downloading again
- update CARLA Python module installation and environment configuration to use the resolved CARLA root
- search for CARLA wheel/egg files across common PythonAPI layouts to handle pre-existing extractions without a `carla\dist` folder

## Testing
- not run (PowerShell is unavailable in the container environment)


------
https://chatgpt.com/codex/tasks/task_e_68d2e466713c832aa08867339180f6ed