### PR TITLE
Fix CARLA readiness check script invocation

### DIFF
--- a/tools/sunnypilot_training/windows/run_full_training.ps1
+++ b/tools/sunnypilot_training/windows/run_full_training.ps1
@@ -150,9 +150,21 @@ except Exception:
 else:
   sys.exit(0)
 '@
-  $script = [string]::Format($scriptTemplate, $CarlaHost, $Port)
-  $process = Start-Process -FilePath $PythonExe -ArgumentList "-c", $script -NoNewWindow -PassThru -Wait
-  return $process.ExitCode -eq 0
+  $scriptContent = [string]::Format($scriptTemplate, $CarlaHost, $Port)
+  $tempScriptPath = [System.IO.Path]::ChangeExtension(
+    [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName()),
+    ".py"
+  )
+  try {
+    [System.IO.File]::WriteAllText($tempScriptPath, $scriptContent)
+    $process = Start-Process -FilePath $PythonExe -ArgumentList $tempScriptPath -NoNewWindow -PassThru -Wait
+    return $process.ExitCode -eq 0
+  }
+  finally {
+    if (Test-Path $tempScriptPath) {
+      Remove-Item -Path $tempScriptPath -Force
+    }
+  }
 }
 
 function Wait-CarlaReady {


### PR DESCRIPTION
## Summary
- write the CARLA readiness test script to a temporary file before execution
- invoke Python with the temporary script file to avoid command-line parsing issues on Windows

## Testing
- Not run (Windows-only script not executable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d31681dfa4832a8b6ef1152bdfe933