### PR TITLE
Fix CARLA launch handling in Windows training scripts

### DIFF
--- a/tools/sunnypilot_training/windows/start_carla.ps1
+++ b/tools/sunnypilot_training/windows/start_carla.ps1
@@ -7,24 +7,82 @@ Param(
 $ErrorActionPreference = "Stop"
 
 if (-Not $CarlaPath) {
-  $envRoot = [Environment]::GetEnvironmentVariable("CARLA_ROOT", "User")
-  if (-Not $envRoot) {
+  foreach ($scope in @(
+      "Process",
+      "User",
+      "Machine"
+    )) {
+    $value = [Environment]::GetEnvironmentVariable("CARLA_ROOT", $scope)
+    if ($value) {
+      $CarlaPath = $value
+      break
+    }
+  }
+  if (-Not $CarlaPath) {
     $CarlaPath = "$PSScriptRoot/../../..\CARLA_0.10.0"
   }
-  else {
-    $CarlaPath = $envRoot
+}
+
+$CarlaPath = [System.IO.Path]::GetFullPath($CarlaPath)
+$carlaExe = $null
+$searchBases = @()
+
+if (Test-Path $CarlaPath -PathType Leaf) {
+  if ($CarlaPath.ToLower().EndsWith('.exe')) {
+    $carlaExe = $CarlaPath
+  }
+  $searchBases = @([System.IO.Path]::GetDirectoryName($CarlaPath))
+}
+
+if (-Not $carlaExe) {
+  if (-not $searchBases) {
+    $searchBases = @($CarlaPath, (Join-Path $CarlaPath "WindowsNoEditor"))
+  }
+  foreach ($base in $searchBases | Where-Object { $_ }) {
+    foreach ($exeName in @(
+        "CarlaUnreal.exe",
+        "CarlaUE4.exe"
+      )) {
+      $candidate = Join-Path $base $exeName
+      if (Test-Path $candidate) {
+        $carlaExe = $candidate
+        break
+      }
+    }
+    if ($carlaExe) { break }
   }
 }
 
-$carlaExe = Join-Path $CarlaPath "CarlaUE4.exe"
-if (-Not (Test-Path $carlaExe)) {
-  throw "CARLA executable not found at $carlaExe"
+if (-Not $carlaExe) {
+  $expected = foreach ($base in $searchBases | Where-Object { $_ }) {
+    foreach ($exeName in @(
+        "CarlaUnreal.exe",
+        "CarlaUE4.exe"
+      )) {
+      Join-Path $base $exeName
+    }
+  }
+  if ($CarlaPath.ToLower().EndsWith('.exe')) {
+    $expected += $CarlaPath
+  }
+  $expectedList = ($expected) -join ', '
+  throw "CARLA executable not found. Expected: $expectedList"
 }
 
-$arguments = @("-RenderOffScreen", "-quality-level=Epic", "-ResX=1920", "-ResY=1080", "-world-port=$Port")
+$arguments = @(
+  "-RenderOffScreen",
+  "-quality-level=Epic",
+  "-ResX=1920",
+  "-ResY=1080",
+  "-carla-rpc-port=$Port"
+)
 if (-Not $Offscreen) {
-  $arguments = @("-quality-level=Epic", "-world-port=$Port")
+  $arguments = @(
+    "-quality-level=Epic",
+    "-carla-rpc-port=$Port"
+  )
 }
 
-Start-Process -FilePath $carlaExe -ArgumentList $arguments -NoNewWindow
+$workingDir = Split-Path -Path $carlaExe -Parent
+Start-Process -FilePath $carlaExe -ArgumentList $arguments -NoNewWindow -WorkingDirectory $workingDir
 Write-Host "CARLA launched on port $Port"


### PR DESCRIPTION
## Summary
- resolve CARLA_ROOT by checking process, user, and machine scopes and fall back to the repo default
- harden CARLA executable discovery, accepting installs that live under WindowsNoEditor or directly point to the .exe
- launch CARLA with the documented -carla-rpc-port flag and use the executable directory as the working directory

## Testing
- not run (PowerShell scripts only)

------
https://chatgpt.com/codex/tasks/task_e_68d31a2efe64832a8c1337cf22a09807