### PR TITLE
Update CARLA launcher detection for Windows scripts

### DIFF
--- a/tools/sunnypilot_training/windows/start_carla.ps1
+++ b/tools/sunnypilot_training/windows/start_carla.ps1
@@ -34,15 +34,49 @@ if (Test-Path $CarlaPath -PathType Leaf) {
   $searchBases = @([System.IO.Path]::GetDirectoryName($CarlaPath))
 }
 
+$candidateExeNames = @(
+  "CarlaUnreal.exe",
+  "CarlaUE4.exe",
+  "CarlaUnreal-Win64-Shipping.exe",
+  "CarlaUE4-Win64-Shipping.exe"
+)
+$relativeSearchPaths = @(
+  "",
+  "WindowsNoEditor",
+  "CarlaUnreal",
+  "CarlaUE4",
+  "CarlaUnreal\\Binaries\\Win64",
+  "CarlaUE4\\Binaries\\Win64",
+  "WindowsNoEditor\\CarlaUnreal\\Binaries\\Win64",
+  "WindowsNoEditor\\CarlaUE4\\Binaries\\Win64"
+)
+
 if (-Not $carlaExe) {
   if (-not $searchBases) {
     $searchBases = @($CarlaPath, (Join-Path $CarlaPath "WindowsNoEditor"))
   }
+
+  $candidateBases = New-Object System.Collections.Generic.List[string]
   foreach ($base in $searchBases | Where-Object { $_ }) {
-    foreach ($exeName in @(
-        "CarlaUnreal.exe",
-        "CarlaUE4.exe"
-      )) {
+    foreach ($relative in $relativeSearchPaths) {
+      if ([string]::IsNullOrWhiteSpace($relative)) {
+        $candidateBase = $base
+      }
+      else {
+        $candidateBase = Join-Path $base $relative
+      }
+
+      if ($candidateBase -and -not $candidateBases.Contains($candidateBase)) {
+        $candidateBases.Add($candidateBase)
+      }
+    }
+  }
+
+  foreach ($base in $candidateBases) {
+    if (-not (Test-Path $base)) {
+      continue
+    }
+    foreach ($exeName in $candidateExeNames) {
       $candidate = Join-Path $base $exeName
       if (Test-Path $candidate) {
         $carlaExe = $candidate
@@ -51,22 +85,19 @@ if (-Not $carlaExe) {
     }
     if ($carlaExe) { break }
   }
-}
 
-if (-Not $carlaExe) {
-  $expected = foreach ($base in $searchBases | Where-Object { $_ }) {
-    foreach ($exeName in @(
-        "CarlaUnreal.exe",
-        "CarlaUE4.exe"
-      )) {
-      Join-Path $base $exeName
+  if (-Not $carlaExe) {
+    $expected = foreach ($base in $candidateBases) {
+      foreach ($exeName in $candidateExeNames) {
+        Join-Path $base $exeName
+      }
     }
+    if ($CarlaPath.ToLower().EndsWith('.exe')) {
+      $expected += $CarlaPath
+    }
+    $expectedList = ($expected) -join ', '
+    throw "CARLA executable not found. Expected: $expectedList"
   }
-  if ($CarlaPath.ToLower().EndsWith('.exe')) {
-    $expected += $CarlaPath
-  }
-  $expectedList = ($expected) -join ', '
-  throw "CARLA executable not found. Expected: $expectedList"
 }
 
 $arguments = @(


### PR DESCRIPTION
## Summary
- expand CARLA executable discovery to include the Win64 shipping binaries when launching CARLA during full training
- apply the same discovery logic to the standalone start_carla.ps1 helper so manual launches use the correct executable

## Testing
- not run (PowerShell-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d420bd046c832aaff8c82a988bf152