### PR TITLE
Fix CARLA Python path join

### DIFF
--- a/tools/sunnypilot_training/windows/setup_env.ps1
+++ b/tools/sunnypilot_training/windows/setup_env.ps1
@@ -218,8 +218,8 @@ function Find-CarlaPythonPackage {
   }
 
   $candidateDirs = @(
-    Join-Path $pythonApi "carla\dist",
-    Join-Path $pythonApi "dist"
+    (Join-Path $pythonApi "carla\dist"),
+    (Join-Path $pythonApi "dist")
   )
 
   foreach ($dir in $candidateDirs) {


### PR DESCRIPTION
## Summary
- fix the Windows setup script so Join-Path receives string inputs when searching for CARLA Python packages

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d438824ce4832a96ab0be0fb4ab010