### PR TITLE
Fix Windows training setup for CARLA Python 3.10 wheel

### DIFF
--- a/tools/sunnypilot_training/windows/setup_env.ps1
+++ b/tools/sunnypilot_training/windows/setup_env.ps1
@@ -1,5 +1,5 @@
 Param(
-  [string]$PythonVersion = "3.11.9",
+  [string]$PythonVersion = "3.10.14",
   [switch]$InstallCUDA,
   [string]$CarlaVersion = "0.10.0",
   [string]$InstallDir = "$PSScriptRoot/../../.."
@@ -396,6 +396,13 @@ function Install-CarlaPythonModule {
     (Join-Path $pythonApi 'util'),
     (Join-Path $pythonApi 'agents')
   ) | Where-Object { Test-Path $_ }
+
+  if ($null -ne $additionalPaths) {
+    $additionalPaths = @($additionalPaths)
+  }
+  else {
+    $additionalPaths = @()
+  }
 
   if ($additionalPaths.Count -gt 0) {
     $pthPath = Join-Path $VenvPath "Lib\site-packages\carla_paths.pth"


### PR DESCRIPTION
## Summary
- default the Windows training setup script to Python 3.10 to match the bundled CARLA wheel
- guard CARLA auxiliary path collection so the script no longer crashes when only one path is present

## Testing
- not run (Windows-only script)


------
https://chatgpt.com/codex/tasks/task_e_68d43b0abab8832ab5d9623314290ec7