### PR TITLE
Fix CARLA process detection for training

### DIFF
--- a/tools/sunnypilot_training/collector/collect_data.py
+++ b/tools/sunnypilot_training/collector/collect_data.py
@@ -5,6 +5,7 @@ import argparse
 import logging
 import math
 import queue
+import sys
 from collections import deque
 from dataclasses import dataclass
 from pathlib import Path
@@ -12,7 +13,13 @@ from typing import Deque, Dict, Iterable, List, Optional, Tuple
 
 import numpy as np
 
-from openpilot.selfdrive.modeld.constants import ModelConstants
+try:
+  from openpilot.selfdrive.modeld.constants import ModelConstants
+except ModuleNotFoundError:
+  repo_root = Path(__file__).resolve().parents[2]
+  if str(repo_root) not in sys.path:
+    sys.path.insert(0, str(repo_root))
+  from selfdrive.modeld.constants import ModelConstants
 
 from ..dataset import DEFAULT_SCHEMA, ZarrShardWriter
 from ..sensors import (

--- a/tools/sunnypilot_training/windows/run_full_training.ps1
+++ b/tools/sunnypilot_training/windows/run_full_training.ps1
@@ -100,7 +100,14 @@ function Start-CarlaProcess {
     [int]$Port,
     [string]$RepoRoot
   )
-  $processNames = @("CarlaUnreal", "CarlaUE4")
+  $processNames = @(
+    "CarlaUnreal",
+    "CarlaUE4",
+    "CarlaUnreal-Win64-Shipping",
+    "CarlaUE4-Win64-Shipping",
+    "CarlaUE5",
+    "CarlaUE5-Win64-Shipping"
+  )
   $existing = foreach ($name in $processNames) {
     Get-Process -Name $name -ErrorAction SilentlyContinue
   }


### PR DESCRIPTION
## Summary
- update the Windows training pipeline to detect UE5-based Carla executables before launching a new instance
- prevent rerunning the pipeline while an existing Carla server is still bound to the RPC port
- ensure the data collector can import model constants when running from a local sunnypilot checkout

## Testing
- `python -m compileall tools/sunnypilot_training/collector/collect_data.py`


------
https://chatgpt.com/codex/tasks/task_e_68d4432c7764832abb4827c51040f3ac