### PR TITLE
Expand sigmoid tuner bins to 70 mph

### DIFF
--- a/sunnypilot/selfdrive/controls/lib/nnlc/sigmoid_map_tuner.py
+++ b/sunnypilot/selfdrive/controls/lib/nnlc/sigmoid_map_tuner.py
@@ -1,0 +1,399 @@
+"""
+Copyright (c) 2021-, Haibin Wen, sunnypilot, and a number of other contributors.
+
+This file is part of sunnypilot and is licensed under the MIT License.
+See the LICENSE.md file in the root directory for more details.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+from dataclasses import dataclass
+from typing import Callable, Dict, List, Optional, Tuple
+
+import numpy as np
+
+from opendbc.sunnypilot.car.interfaces import LatControlInputs
+from openpilot.common.swaglog import cloudlog
+from openpilot.system.hardware.hw import Paths
+
+
+MPH_TO_MS = 0.44704
+MAX_TUNING_SPEED = 70.0 * MPH_TO_MS
+MIN_TUNING_SPEED = 5.0 * MPH_TO_MS  # 5 mph
+EMA_ALPHA = 0.2
+DEFAULT_MIN_BIN_SAMPLES = 20
+MIN_READY_SPEED_SLICES = 5
+HIGH_LAT_ACCEL_THRESHOLD = 2.0  # m/s^2
+LOW_LAT_ACCEL_THRESHOLD = 0.4
+MAX_SLICE_MSE = 0.35
+LOGISTIC_EPS = 1e-4
+FRICTION_SAMPLE_THRESHOLD = 0.3
+LAT_ACCEL_SEARCH_RANGE = 6.0
+
+
+@dataclass
+class BinValue:
+  lat_accel: float = 0.0
+  torque: float = 0.0
+  torque_space: float = 0.0
+  count: int = 0
+
+
+@dataclass
+class SigmoidSlice:
+  speed: float
+  slope: float
+  intercept: float
+
+
+class SigmoidMapSolution:
+  def __init__(self, slices: List[SigmoidSlice]):
+    self.slices = sorted(slices, key=lambda s: s.speed)
+
+  def serialize(self) -> Dict[str, List[Dict[str, float]]]:
+    return {
+      "slices": [
+        {"speed": s.speed, "slope": s.slope, "intercept": s.intercept}
+        for s in self.slices
+      ],
+    }
+
+  @staticmethod
+  def deserialize(data: Dict[str, List[Dict[str, float]]]) -> "SigmoidMapSolution":
+    slices = [SigmoidSlice(speed=s["speed"], slope=s["slope"], intercept=s["intercept"]) for s in data.get("slices", [])]
+    return SigmoidMapSolution(slices)
+
+  def params_at_speed(self, speed: float) -> Optional[Tuple[float, float]]:
+    if not self.slices:
+      return None
+
+    if speed <= self.slices[0].speed:
+      return self.slices[0].slope, self.slices[0].intercept
+    if speed >= self.slices[-1].speed:
+      return self.slices[-1].slope, self.slices[-1].intercept
+
+    for low, high in zip(self.slices[:-1], self.slices[1:]):
+      if low.speed <= speed <= high.speed:
+        ratio = 0.0 if high.speed == low.speed else (speed - low.speed) / (high.speed - low.speed)
+        slope = low.slope + ratio * (high.slope - low.slope)
+        intercept = low.intercept + ratio * (high.intercept - low.intercept)
+        return slope, intercept
+
+    return None
+
+
+class SigmoidMapTuner:
+  def __init__(self,
+               lac_torque,
+               torque_params,
+               torque_from_lateral_accel_in_torque_space: Callable,
+               car_fingerprint: str,
+               freeze_when_solution_loaded: bool = True,
+               min_bin_samples: int = DEFAULT_MIN_BIN_SAMPLES):
+    self.lac_torque = lac_torque
+    self.torque_params = torque_params
+    self._torque_from_lateral_accel_in_torque_space = torque_from_lateral_accel_in_torque_space
+
+    self._base_torque_from_lataccel = lac_torque.torque_from_lateral_accel
+    self._base_lataccel_from_torque = lac_torque.lateral_accel_from_torque
+    self._freeze_when_solution_loaded = freeze_when_solution_loaded
+    self._min_bin_samples = max(1, min_bin_samples)
+
+    self._storage_dirs = self._candidate_storage_dirs()
+    self._file_name = f"{car_fingerprint}_nnlc.json"
+    self._file_path = os.path.join(self._storage_dirs[0], self._file_name)
+    self._current_speed = 0.0
+    self._solution: Optional[SigmoidMapSolution] = None
+    self._current_roll_compensation = 0.0
+    self._current_longitudinal_accel = 0.0
+    self._frozen_from_disk = False
+
+    mph_edges = np.arange(5.0, 75.0, 5.0) * MPH_TO_MS
+    self._speed_edges = mph_edges
+    self._speed_centers = 0.5 * (self._speed_edges[1:] + self._speed_edges[:-1])
+    self._lat_edges = np.linspace(-4.0, 4.0, 33)  # 0.25 m/s^2 bins
+
+    self._bins: Dict[Tuple[int, int], BinValue] = {}
+    self._install_wrappers()
+    self._load_solution()
+
+  # ---------------------------------------------------------------------------
+  # Public API
+  # ---------------------------------------------------------------------------
+  def observe(self,
+              enabled: bool,
+              CS,
+              setpoint: float,
+              measurement: float,
+              desired_lat_accel: float,
+              output_torque: float,
+              steer_limited: bool,
+              roll_compensation: float) -> None:
+    self._current_speed = CS.vEgo
+    self._current_longitudinal_accel = CS.aEgo
+    self._current_roll_compensation = roll_compensation
+
+    if self._frozen_from_disk:
+      return
+
+    if not enabled:
+      return
+
+    if steer_limited or CS.steeringPressed:
+      return
+
+    if CS.vEgo < MIN_TUNING_SPEED or CS.vEgo > MAX_TUNING_SPEED:
+      return
+
+    lat_error = abs(setpoint - measurement)
+    if lat_error > 0.5:
+      return
+
+    if abs(desired_lat_accel) < LOW_LAT_ACCEL_THRESHOLD:
+      return
+
+    idx_speed = self._speed_index(CS.vEgo)
+    idx_lat = self._lat_index(desired_lat_accel)
+    if idx_speed is None or idx_lat is None:
+      return
+
+    lat_inputs = LatControlInputs(desired_lat_accel, roll_compensation, CS.vEgo, CS.aEgo)
+    torque_space = float(self._torque_from_lateral_accel_in_torque_space(lat_inputs, self.torque_params, gravity_adjusted=True))
+
+    key = (idx_speed, idx_lat)
+    bin_value = self._bins.setdefault(key, BinValue())
+    bin_value.count += 1
+    bin_value.lat_accel = self._ema(bin_value.lat_accel, desired_lat_accel)
+    bin_value.torque = self._ema(bin_value.torque, float(np.clip(output_torque, -self.lac_torque.steer_max, self.lac_torque.steer_max)))
+    bin_value.torque_space = self._ema(bin_value.torque_space, torque_space)
+
+    if self._ready_to_solve():
+      solution = self._solve()
+      if solution is not None:
+        self._apply_solution(solution)
+
+  # ---------------------------------------------------------------------------
+  # Internal helpers
+  # ---------------------------------------------------------------------------
+  def _install_wrappers(self) -> None:
+    def torque_from_lataccel(lat_accel, torque_params):
+      params = self._solution.params_at_speed(self._current_speed) if self._solution is not None else None
+      if params is None or self._current_speed < MIN_TUNING_SPEED:
+        return self._base_torque_from_lataccel(lat_accel, torque_params)
+
+      slope, intercept = params
+      lat_inputs = LatControlInputs(lat_accel,
+                                    self._current_roll_compensation,
+                                    self._current_speed,
+                                    self._current_longitudinal_accel)
+      torque_space = float(self._torque_from_lateral_accel_in_torque_space(lat_inputs, torque_params, gravity_adjusted=True))
+      torque = self._predict_torque_from_space(torque_space, slope, intercept)
+      return float(np.clip(torque, -self.lac_torque.steer_max, self.lac_torque.steer_max))
+
+    def lataccel_from_torque(torque, torque_params):
+      params = self._solution.params_at_speed(self._current_speed) if self._solution is not None else None
+      if params is None or self._current_speed < MIN_TUNING_SPEED:
+        return self._base_lataccel_from_torque(torque, torque_params)
+
+      slope, intercept = params
+      torque_space = self._torque_space_from_torque(torque, slope, intercept)
+      if torque_space is None:
+        return self._base_lataccel_from_torque(torque, torque_params)
+      return float(self._latacc_from_torque_space(torque_space))
+
+    self.lac_torque.torque_from_lateral_accel = torque_from_lataccel
+    self.lac_torque.lateral_accel_from_torque = lataccel_from_torque
+
+  def _ema(self, prev: float, new: float) -> float:
+    if math.isclose(prev, 0.0, abs_tol=1e-6):
+      return new
+    return EMA_ALPHA * new + (1.0 - EMA_ALPHA) * prev
+
+  def _speed_index(self, speed: float) -> Optional[int]:
+    idx = np.digitize(speed, self._speed_edges) - 1
+    if 0 <= idx < len(self._speed_centers):
+      return idx
+    return None
+
+  def _lat_index(self, lat_accel: float) -> Optional[int]:
+    idx = np.digitize(lat_accel, self._lat_edges) - 1
+    if 0 <= idx < len(self._lat_edges) - 1:
+      return idx
+    return None
+
+  def _ready_to_solve(self) -> bool:
+    ready_slices = 0
+    for speed_idx in range(len(self._speed_centers)):
+      if self._slice_has_coverage(speed_idx):
+        ready_slices += 1
+    if not self._frozen_from_disk:
+      cloudlog.event("sigmoid_map_tuner_ready",
+                     ready_slices=ready_slices,
+                     required_slices=MIN_READY_SPEED_SLICES,
+                     bin_count=len(self._bins))
+    return ready_slices >= MIN_READY_SPEED_SLICES
+
+  def _slice_has_coverage(self, speed_idx: int) -> bool:
+    pos_high = False
+    neg_high = False
+    mid = False
+    for (idx_speed, idx_lat), value in self._bins.items():
+      if idx_speed != speed_idx or value.count < self._min_bin_samples:
+        continue
+      lat = value.lat_accel
+      if abs(lat) >= HIGH_LAT_ACCEL_THRESHOLD:
+        if lat > 0:
+          pos_high = True
+        else:
+          neg_high = True
+      if abs(lat) <= HIGH_LAT_ACCEL_THRESHOLD and abs(lat) >= LOW_LAT_ACCEL_THRESHOLD:
+        mid = True
+    return pos_high and neg_high and mid
+
+  def _solve(self) -> Optional[SigmoidMapSolution]:
+    slices: List[SigmoidSlice] = []
+    for speed_idx, speed_center in enumerate(self._speed_centers):
+      slice_bins = [value for (idx_speed, _), value in self._bins.items() if idx_speed == speed_idx and value.count >= self._min_bin_samples]
+      if len(slice_bins) < 3:
+        continue
+
+      lats = np.array([b.lat_accel for b in slice_bins])
+      torque_space = np.array([b.torque_space for b in slice_bins])
+      torques = np.array([b.torque for b in slice_bins])
+      if np.all(lats <= 0.0) or np.all(lats >= 0.0):
+        continue
+
+      slope, intercept = self._fit_logistic(torque_space, torques)
+      if slope is None:
+        continue
+
+      slices.append(SigmoidSlice(speed=speed_center, slope=slope, intercept=intercept))
+
+    if len(slices) < MIN_READY_SPEED_SLICES:
+      return None
+
+    return SigmoidMapSolution(slices)
+
+  def _fit_logistic(self, torque_space: np.ndarray, torques: np.ndarray) -> Tuple[Optional[float], Optional[float]]:
+    steer_max = self.lac_torque.steer_max
+    torque_norm = np.clip(0.5 * (torques / steer_max + 1.0), LOGISTIC_EPS, 1.0 - LOGISTIC_EPS)
+    logits = np.log(torque_norm / (1.0 - torque_norm))
+    A = np.vstack([torque_space, np.ones_like(torque_space)]).T
+    try:
+      slope, intercept = np.linalg.lstsq(A, logits, rcond=None)[0]
+    except np.linalg.LinAlgError:
+      return None, None
+
+    pred = self._predict_torque_from_space(torque_space, slope, intercept)
+    mse = float(np.mean((pred - torques) ** 2))
+    if mse > MAX_SLICE_MSE:
+      return None, None
+
+    return slope, intercept
+
+  def _predict_torque_from_space(self, torque_space, slope: float, intercept: float):
+    logits = slope * torque_space + intercept
+    torque_norm = 1.0 / (1.0 + np.exp(-logits))
+    return (2.0 * torque_norm - 1.0) * self.lac_torque.steer_max
+
+  def _torque_space_from_torque(self, torque, slope: float, intercept: float) -> Optional[float]:
+    steer_max = self.lac_torque.steer_max
+    torque_norm = 0.5 * (np.clip(torque, -steer_max, steer_max) / steer_max + 1.0)
+    torque_norm = np.clip(torque_norm, LOGISTIC_EPS, 1.0 - LOGISTIC_EPS)
+    logits = np.log(torque_norm / (1.0 - torque_norm))
+    if abs(slope) < 1e-4:
+      return None
+    return (logits - intercept) / slope
+
+  def _latacc_from_torque_space(self, torque_space: float) -> float:
+    low = -LAT_ACCEL_SEARCH_RANGE
+    high = LAT_ACCEL_SEARCH_RANGE
+    for _ in range(16):
+      mid = 0.5 * (low + high)
+      lat_inputs = LatControlInputs(mid,
+                                    self._current_roll_compensation,
+                                    self._current_speed,
+                                    self._current_longitudinal_accel)
+      mid_torque = float(self._torque_from_lateral_accel_in_torque_space(lat_inputs, self.torque_params, gravity_adjusted=True))
+      if torque_space >= mid_torque:
+        low = mid
+      else:
+        high = mid
+    return 0.5 * (low + high)
+
+  def _apply_solution(self, solution: SigmoidMapSolution) -> None:
+    self._solution = solution
+    self._write_solution()
+    self._update_torque_params()
+
+  def _update_torque_params(self) -> None:
+    if self._solution is None or not self._solution.slices:
+      return
+
+    lat_accel_factor = self._estimate_latacc_factor()
+    offset_samples = [value.lat_accel for value in self._bins.values()
+                      if value.count >= self._min_bin_samples and abs(value.torque) < 0.1]
+    friction_samples = [abs(value.torque) for value in self._bins.values()
+                        if value.count >= self._min_bin_samples and abs(value.lat_accel) < FRICTION_SAMPLE_THRESHOLD]
+
+    lat_accel_offset = float(np.clip(np.median(offset_samples), -1.0, 1.0)) if offset_samples else self.torque_params.latAccelOffset
+    friction = float(np.clip(np.median(friction_samples), 0.05, 3.0)) if friction_samples else self.torque_params.friction
+
+    if lat_accel_factor is None:
+      lat_accel_factor = self.torque_params.latAccelFactor
+
+    self.lac_torque.update_live_torque_params(lat_accel_factor, lat_accel_offset, friction)
+
+  def _estimate_latacc_factor(self) -> Optional[float]:
+    slopes = []
+    for value in self._bins.values():
+      if value.count < self._min_bin_samples:
+        continue
+      if abs(value.torque) < 1e-3:
+        continue
+      slopes.append(value.lat_accel / value.torque)
+    if not slopes:
+      return None
+    return float(np.clip(np.median(slopes), 0.01, 10.0))
+
+  def _write_solution(self) -> None:
+    if self._solution is None or self._frozen_from_disk:
+      return
+
+    serialized = self._solution.serialize()
+    for directory in self._storage_dirs:
+      path = os.path.join(directory, self._file_name)
+      try:
+        os.makedirs(directory, exist_ok=True)
+        with open(path, "w", encoding="utf-8") as f:
+          json.dump(serialized, f)
+        self._file_path = path
+        return
+      except OSError as e:
+        cloudlog.event("sigmoid_map_tuner_write_failed", path=path, error=str(e))
+
+  def _load_solution(self) -> None:
+    for directory in self._storage_dirs:
+      path = os.path.join(directory, self._file_name)
+      if not os.path.exists(path):
+        continue
+      try:
+        with open(path, "r", encoding="utf-8") as f:
+          data = json.load(f)
+        solution = SigmoidMapSolution.deserialize(data)
+        if solution.slices:
+          self._solution = solution
+          self._file_path = path
+          if self._freeze_when_solution_loaded:
+            self._frozen_from_disk = True
+          self._update_torque_params()
+        return
+      except (OSError, json.JSONDecodeError):
+        continue
+
+  def _candidate_storage_dirs(self) -> List[str]:
+    return ["/data/params/d_tmp/sigmoid_maps"]
+

--- a/tools/sigmoid_map_analyzer.py
+++ b/tools/sigmoid_map_analyzer.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Summarize NNLC sigmoid map JSON files.
+
+This helper inspects sigmoid map slices (speed, slope, intercept) and reports
+coverage against an expected speed grid along with basic slope/intercept stats.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Iterable, List
+
+MPH_TO_MS = 0.44704
+MS_TO_MPH = 1.0 / MPH_TO_MS
+
+
+def _load_slices(path: Path) -> List[dict]:
+  with open(path, "r", encoding="utf-8") as f:
+    data = json.load(f)
+  slices = data.get("slices", [])
+  if not isinstance(slices, list):
+    raise ValueError("Expected 'slices' list in map JSON")
+  return slices
+
+
+def _expected_centers(min_speed_mph: float, max_speed_mph: float, step_mph: float) -> List[float]:
+  centers: List[float] = []
+  current = min_speed_mph
+  while current <= max_speed_mph + 1e-6:
+    centers.append(current)
+    current += step_mph
+  return centers
+
+
+def _missing_speeds(actual_mph: Iterable[float], expected_mph: Iterable[float], tolerance_mph: float) -> List[float]:
+  actual_sorted = sorted(actual_mph)
+  missing: List[float] = []
+  for target in expected_mph:
+    found = any(abs(target - value) <= tolerance_mph for value in actual_sorted)
+    if not found:
+      missing.append(target)
+  return missing
+
+
+def _describe(values: List[float]) -> str:
+  if not values:
+    return "n/a"
+  minimum = min(values)
+  maximum = max(values)
+  mean = sum(values) / len(values)
+  return f"min={minimum:.3f}, max={maximum:.3f}, mean={mean:.3f}"
+
+
+def summarize_map(path: Path, min_speed_mph: float, max_speed_mph: float, step_mph: float, tolerance_mph: float) -> str:
+  slices = _load_slices(path)
+  if not slices:
+    return "No slices found in map JSON."
+
+  speeds_mph = [slice_["speed"] * MS_TO_MPH for slice_ in slices]
+  slopes = [slice_["slope"] for slice_ in slices]
+  intercepts = [slice_["intercept"] for slice_ in slices]
+
+  expected = _expected_centers(min_speed_mph, max_speed_mph, step_mph)
+  missing = _missing_speeds(speeds_mph, expected, tolerance_mph)
+  coverage = 100.0 * (1.0 - len(missing) / len(expected)) if expected else 0.0
+
+  lines = [
+    f"File: {path}",
+    f"Slices: {len(slices)} present, coverage {coverage:.1f}% ({len(expected) - len(missing)}/{len(expected)})",
+    f"Speed centers (mph): { _describe(speeds_mph) }",
+    f"Slope stats: { _describe(slopes) }",
+    f"Intercept stats: { _describe(intercepts) }",
+  ]
+
+  if missing:
+    missing_str = ", ".join(f"{m:.1f}" for m in missing)
+    lines.append(f"Missing expected speed centers (mph): {missing_str}")
+
+  return "\n".join(lines)
+
+
+def main() -> None:
+  parser = argparse.ArgumentParser(description="Summarize an NNLC sigmoid map JSON file")
+  parser.add_argument("map_json", type=Path, help="Path to the sigmoid map JSON")
+  parser.add_argument("--min-speed", type=float, default=5.0, help="Minimum expected speed center in mph (default: 5)")
+  parser.add_argument("--max-speed", type=float, default=70.0, help="Maximum expected speed center in mph (default: 70)")
+  parser.add_argument("--step", type=float, default=5.0, help="Expected speed center step in mph (default: 5)")
+  parser.add_argument("--tolerance", type=float, default=2.5, help="Tolerance when matching expected centers in mph (default: half a bin)")
+  args = parser.parse_args()
+
+  summary = summarize_map(args.map_json, args.min_speed, args.max_speed, args.step, args.tolerance)
+  print(summary)
+
+
+if __name__ == "__main__":
+  main()

--- a/tools/sigmoid_map_from_logs.py
+++ b/tools/sigmoid_map_from_logs.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Generate NNLC sigmoid map solutions from recorded rlog/qlog files."""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from pathlib import Path
+from typing import Sequence
+
+import numpy as np
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+  sys.path.insert(0, str(REPO_ROOT))
+
+from cereal import car, custom  # noqa: E402
+from opendbc.car.car_helpers import interfaces  # noqa: E402
+from opendbc.car.vehicle_model import VehicleModel  # noqa: E402
+from openpilot.common.constants import ACCELERATION_DUE_TO_GRAVITY  # noqa: E402
+from openpilot.selfdrive.controls.lib.latcontrol_torque import LOW_SPEED_X, LOW_SPEED_Y  # noqa: E402
+from openpilot.sunnypilot.selfdrive.controls.lib.nnlc.sigmoid_map_tuner import SigmoidMapTuner  # noqa: E402
+from tools.lib.logreader import LogReader  # noqa: E402
+
+LOG_GLOB_PATTERNS = ("*.rlog*", "*.qlog*")
+
+
+class OfflineLatControlAdapter:
+  """Minimal LatControlTorque-like object for SigmoidMapTuner."""
+
+  def __init__(self, CI, CP):
+    self.torque_params = CP.lateralTuning.torque.as_builder()
+    self.torque_from_lateral_accel = CI.torque_from_lateral_accel()
+    self.lateral_accel_from_torque = CI.lateral_accel_from_torque()
+    self.steer_max = float(getattr(CP, "steerLimitTorque", 1.0)) or 1.0
+
+  def update_live_torque_params(self, latAccelFactor: float, latAccelOffset: float, friction: float) -> None:
+    self.torque_params.latAccelFactor = latAccelFactor
+    self.torque_params.latAccelOffset = latAccelOffset
+    self.torque_params.friction = friction
+
+
+class OfflineSigmoidMapTuner(SigmoidMapTuner):
+  """Sigmoid tuner that writes solutions to a user-provided directory."""
+
+  def __init__(self, lac_adapter: OfflineLatControlAdapter, CI, CP, output_dir: Path):
+    super().__init__(lac_adapter,
+                     lac_adapter.torque_params,
+                     CI.torque_from_lateral_accel_in_torque_space(),
+                     CP.carFingerprint,
+                     freeze_when_solution_loaded=False)
+    self._storage_dirs = [str(output_dir)]
+    self._file_name = f"{CP.carFingerprint}_nnlc.json"
+
+  def _update_torque_params(self) -> None:  # offline mode never tweaks live params
+    return
+
+
+def _find_logs(path: Path) -> list[Path]:
+  """Return every qlog/rlog under *path*, recursing into subdirectories."""
+
+  if not path.exists():
+    raise FileNotFoundError(f"{path} does not exist")
+
+  if path.is_file():
+    name = path.name
+    if any(token in name for token in (".rlog", ".qlog")):
+      return [path]
+    return []
+
+  paths: set[Path] = set()
+  for pattern in LOG_GLOB_PATTERNS:
+    recursive_pattern = f"**/{pattern}" if not pattern.startswith("**/") else pattern
+    for candidate in path.glob(recursive_pattern):
+      if candidate.is_file():
+        paths.add(candidate)
+  return sorted(paths)
+
+
+def _iter_log_messages(log_paths: Sequence[Path]):
+  for path in log_paths:
+    for msg in LogReader(str(path)):
+      yield msg
+
+
+def _extract_car_params(log_paths: list[Path]) -> tuple[car.CarParams, custom.CarParamsSP]:
+  cp_msg = None
+  cp_sp_msg = None
+  for msg in _iter_log_messages(log_paths):
+    if msg.which() == "carParams" and cp_msg is None:
+      cp_msg = msg.carParams
+    elif msg.which() == "carParamsSP" and cp_sp_msg is None:
+      cp_sp_msg = msg.carParamsSP
+    if cp_msg and cp_sp_msg:
+      break
+  if cp_msg is None:
+    raise RuntimeError("No carParams message found in provided logs")
+  if cp_sp_msg is None:
+    cp_sp_msg = custom.CarParamsSP.new_message()
+  return cp_msg, cp_sp_msg
+
+
+def _process_logs(log_paths: list[Path], output_dir: Path) -> Path:
+  cp_msg, cp_sp_msg = _extract_car_params(log_paths)
+  CI = interfaces[cp_msg.carFingerprint](cp_msg, cp_sp_msg)
+  adapter = OfflineLatControlAdapter(CI, cp_msg)
+  tuner = OfflineSigmoidMapTuner(adapter, CI, cp_msg, output_dir)
+  vm = VehicleModel(cp_msg)
+
+  lp_angle_offset = 0.0
+  lp_roll = 0.0
+  lp_sr = cp_msg.steerRatio
+  lp_stiffness = cp_msg.tireStiffnessFactor
+  last_car_state = None
+
+  for msg in _iter_log_messages(log_paths):
+    which = msg.which()
+    if which == "carState":
+      last_car_state = msg.carState
+    elif which == "liveParameters":
+      lp = msg.liveParameters
+      if lp.steerRatio > 0.0 and lp.stiffnessFactor > 0.0:
+        lp_sr = lp.steerRatio
+        lp_stiffness = lp.stiffnessFactor
+        vm.update_params(lp_stiffness, lp_sr)
+      lp_angle_offset = lp.angleOffsetDeg
+      lp_roll = lp.roll
+    elif which == "controlsState":
+      if last_car_state is None:
+        continue
+      if msg.controlsState.lateralControlState.which() != "torqueState":
+        continue
+      torque_state = msg.controlsState.lateralControlState.torqueState
+      if not torque_state.active:
+        continue
+      desired_curvature = msg.controlsState.desiredCurvature
+      steer_angle = math.radians(last_car_state.steeringAngleDeg - lp_angle_offset)
+      actual_curvature = -vm.calc_curvature(steer_angle, last_car_state.vEgo, lp_roll)
+      low_speed_factor = float(np.interp(last_car_state.vEgo, LOW_SPEED_X, LOW_SPEED_Y)) ** 2
+      setpoint = torque_state.desiredLateralAccel + low_speed_factor * desired_curvature
+      measurement = torque_state.actualLateralAccel + low_speed_factor * actual_curvature
+      roll_comp = lp_roll * ACCELERATION_DUE_TO_GRAVITY
+      output_torque = -float(torque_state.output)
+      tuner.observe(True,
+                    last_car_state,
+                    setpoint,
+                    measurement,
+                    torque_state.desiredLateralAccel,
+                    output_torque,
+                    torque_state.saturated,
+                    roll_comp)
+
+  if tuner._solution is None:
+    solution = tuner._solve()
+    if solution is None:
+      raise RuntimeError("Insufficient coverage to solve for a sigmoid map")
+    serialized = solution.serialize()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_path = output_dir / tuner._file_name
+    with open(output_path, "w", encoding="utf-8") as f:
+      json.dump(serialized, f, indent=2)
+    return output_path
+
+  return Path(tuner._file_path)
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+  parser = argparse.ArgumentParser(description="Generate NNLC sigmoid maps from recorded logs")
+  parser.add_argument("log_dir", type=Path, help="Directory tree to scan for qlog/rlog files")
+  parser.add_argument("--output", type=Path, default=Path("sigmoid_maps"), help="Directory to write the solution JSON")
+  args = parser.parse_args(argv)
+
+  log_paths = _find_logs(args.log_dir)
+  if not log_paths:
+    raise SystemExit(f"No qlog/rlog files found under {args.log_dir}")
+
+  output_path = _process_logs(log_paths, args.output)
+  print(f"Wrote sigmoid map to {output_path}")
+
+
+if __name__ == "__main__":
+  main()


### PR DESCRIPTION
## Summary
- extend sigmoid tuner speed coverage to 5–70 mph with 5 mph slices
- allow configurable minimum samples per bin while keeping the default at 20

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918df273370832a90a7eb2b57c781bc)